### PR TITLE
Add pause/resume feature

### DIFF
--- a/Configuration.h
+++ b/Configuration.h
@@ -9,6 +9,7 @@
 class Configuration {
 public:
     sf::Font font;
+    std::string fontFile; // path to font for saving/loading
     int fontSize;
     int maxWordsLength;
     int moveSpeed;

--- a/Utils.h
+++ b/Utils.h
@@ -62,8 +62,8 @@ private:
     // labels
     sf::Text fontNameDropdownLabel, fontSizeDropdownLabel, speedDropdownLabel, topicDropdownLabel, wordSizeLabel, configLabel, buttonLabel;
 
-    sf::RectangleShape levelOneBtn, levelTwoBtn, scoreBtn, panelConfig, panelButtons;
-    sf::Text levelOneText, levelTwoText, scoreText, panelConfigText, panelButtonsText;
+    sf::RectangleShape levelOneBtn, levelTwoBtn, scoreBtn, continueBtn, panelConfig, panelButtons;
+    sf::Text levelOneText, levelTwoText, scoreText, continueText, panelConfigText, panelButtonsText;
     DropdownCtrl fontNameDropdown;
     DropdownCtrl fontSizeDropdown;
     DropdownCtrl speedDropdown;
@@ -77,8 +77,11 @@ private:
 class Game {
 public:
     Game(Configuration& config, const std::string& resultsFile);
-    void run();
+    void run(bool resume = false);
     void setSpeed();
+    void saveState(const std::vector<sf::Text>& wordTexts, int elapsedSeconds);
+    bool loadState(std::vector<sf::Text>& wordTexts);
+    static bool hasSavedGame(const std::string& filename);
 
 private:
     const int points_for_correct_letter = 10;//amount of points for one letter in correct word

--- a/main.cpp
+++ b/main.cpp
@@ -9,7 +9,8 @@ auto main() -> int{
                                 sf::Style::Titlebar | sf::Style::Close);
 
     Configuration config;//keep configuration settings
-    config.font.loadFromFile("FONTfiles/arial.ttf");//load default system font
+    config.fontFile = "FONTfiles/arial.ttf";
+    config.font.loadFromFile(config.fontFile);//load default system font
     config.fontSize = 40;//font size by default
 
     const std::string resultsFile = "FONTfiles/results.txt";
@@ -27,8 +28,11 @@ auto main() -> int{
         if (choice == 1) { // game
             if (!config.topicWords.empty()) {
                 Game game(config, resultsFile);
-                game.run();
+                game.run(false);
             }
+        } else if (choice == 2) { // continue saved game
+            Game game(config, resultsFile);
+            game.run(true);
         } else if (choice == 0) { // result
             displayResultsWindow(resultsFile, config.font);
         } else {


### PR DESCRIPTION
## Summary
- add font file path to configuration
- implement game save/resume logic
- show a Continue button when save file exists
- allow pausing the game with `P` key and resume later

## Testing
- `cmake -B build` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_6843fb7021a08324b3c1c5074fdc0b93